### PR TITLE
Switch to python rich and blessed

### DIFF
--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -203,6 +203,15 @@ test_system:
   tests:
     - kernel not tainted on boot
 
+# This is just for testing the 'multi' command
+test_filelist:
+  type: test
+  name: Record current file list
+  logs:
+    commands:
+      - run: ls -l
+        output: multi
+
 test_hotplug_libinput:
   type: test
   filter:

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(name='uji',
       data_files=[],  # man pages are added on success
       python_requires='>=3.6',
       include_package_data=True,
-      install_requires=['pyyaml', 'GitPython', 'click', 'curtsies'],
+      install_requires=['pyyaml', 'GitPython', 'click', 'curtsies', 'rich'],
       cmdclass=dict(
           install=ManPageGenerator,
       )

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(name='uji',
       data_files=[],  # man pages are added on success
       python_requires='>=3.6',
       include_package_data=True,
-      install_requires=['pyyaml', 'GitPython', 'click', 'curtsies', 'rich'],
+      install_requires=['pyyaml', 'GitPython', 'blessed', 'click', 'rich'],
       cmdclass=dict(
           install=ManPageGenerator,
       )

--- a/uji.py
+++ b/uji.py
@@ -409,7 +409,7 @@ class MarkdownFormatter(object):
                 if description:
                     self.parent.fprint(f'  - {description}')
             elif output_type == 'human':
-                self.checkbox_command(f'`{command}`: <strong>ADD COMMENTS HERE</strong>')
+                self.checkbox_command(f'`{command}`: **ADD COMMENTS HERE**')
                 if description:
                     self.parent.fprint(f'  - {description}')
 
@@ -1131,7 +1131,7 @@ class UjiView(object):
         # list of regex to deduce the type of command to be run
         command_re = {
                 'attach': r'^(\s*)- \[.\].* \[`(.*)`\]\((.*)\).*',
-                'human': r'^(\s*)- \[.\].* `(.*)`: <strong>(.*)</strong>$',
+                'human': r'^(\s*)- \[.\].* `(.*)`: \*\*(.*)\*\*$',
                 'single': r'^(\s*)- \[.\].* `(.*)`: `(.*)`$',
                 'multi': r'^(\s*)- \[.\].* `(.*)`:$',
                 'exitcode': r'^(\s*)- \[.\].* `(.*)`$',

--- a/uji.py
+++ b/uji.py
@@ -851,6 +851,8 @@ class UjiView(object):
             Keymapping('KEY_PGUP', 'page down', func=self.page_up),
             Keymapping('n', 'next', func=self.next),
             Keymapping('p', 'previous', func=self.previous),
+            Keymapping('N', 'next section', func=self.next_section),
+            Keymapping('U', 'previous section', func=self.prev_section),
             Keymapping('r', 'run command', flags=[KeymappingFlags.ONLY_ON_CHECKBOX, KeymappingFlags.EXECUTE], func=self.execute_command),
             Keymapping('t', 'toggle', flags=[KeymappingFlags.ONLY_ON_CHECKBOX], func=self.toggle),
             Keymapping('u', 'upload', flags=[KeymappingFlags.ONLY_ON_CHECKBOX, KeymappingFlags.UPLOAD], func=self.upload),
@@ -1040,6 +1042,24 @@ class UjiView(object):
             if self.is_checkbox(l):
                 self._update_cursor(idx)
                 break
+
+    def next_section(self):
+        for idx, (current, next) in enumerate(zip(self.lines[self.cursor_offset + 1:-1],
+                                                  self.lines[self.cursor_offset + 2:])):
+            if self.is_header(current, next):
+                self.cursor_offset = self.cursor_offset + 1 + idx
+                break
+
+    def prev_section(self):
+        for idx, (current, next) in enumerate(zip(reversed(self.lines[0:self.cursor_offset - 1]),
+                                                   reversed(self.lines[1:self.cursor_offset]))):
+            if self.is_header(current, next):
+                self.cursor_offset = self.cursor_offset - idx - 2
+                break
+
+    def is_header(self, current, next):
+        return (re.match(r'^(#{1,}\s?)(.*)', current) or
+                re.match(r'^[=\-._]{3,}$', next) and len(current) == len(next))
 
     def is_checkbox(self, line):
         return re.match(r'^\s*- \[[ xX]\].*', line) is not None

--- a/uji.py
+++ b/uji.py
@@ -915,7 +915,8 @@ class UjiView(object):
                            lambda m: f'[header]{m.group(2)}{" " * (80 - len(m.group(1)) - len(m.group(2)))}[/header]', l)
 
                 # checkboxes [ ], [x] or [X], must be escaped with one backslah (e.g. \[x]) to prevent rich from parsing it as markup
-                l = re.sub(r'^(\s*- )(\[[ xX]\] )(.*)', r'[checkbox]\1\\\2\3[/checkbox]', l)
+                l = re.sub(r'^(\s*- )(\[[xX]\] )(.*)', r'[checkbox_done]\1\\\2\3[/checkbox_done]', l)
+                l = re.sub(r'^(\s*- )(\[[ ]\] )(.*)', r'[checkbox]\1\\\2\3[/checkbox]', l)
 
             rendered.append(l)
 

--- a/uji.py
+++ b/uji.py
@@ -403,7 +403,6 @@ class MarkdownFormatter(object):
                     self.parent.fprint(f'  - {description}')
                 self.parent.fprint(f'```')
                 self.parent.fprint(f'   COMMAND OUTPUT')
-                self.parent.fprint(f'')
                 self.parent.fprint(f'```')
             elif output_type == 'attach':
                 self.checkbox_command(f'[`{command}`]({filename})')

--- a/uji.py
+++ b/uji.py
@@ -1361,7 +1361,7 @@ class UjiView(object):
         if self.error:
             return f'[error]{self.error}[/error]'
 
-        commands = [self.keymap[k] for k in ['j', 'k', 'n', 'p', 'e', 'q', 'r', 't', 'u', 'f']]
+        commands = [self.keymap[k] for k in ['e', 'r', 't', 'u', 'f']]
 
         statusline = ['[statusline] ---']
         for k in commands:

--- a/uji.py
+++ b/uji.py
@@ -1152,11 +1152,11 @@ class UjiView(object):
                 command_match = match
                 break
 
-        if command_type is None:
+        if command_type is None or command_match is None:
             logger.error(f'Failed to match run command line: {line}')
             return
 
-        command = match[2]
+        command = command_match[2]
         output = []
         insert_offset = self.cursor_offset + 1
         offset = -1

--- a/uji.py
+++ b/uji.py
@@ -51,13 +51,14 @@ from textwrap import dedent
 # Stylesheet for uji view
 style = '''
 [styles]
-header = bold on cyan
-filename = underline blue
-inline = red
-checkbox = green
-code = on yellow
+header = #9a56a9 on #dddddd
+filename = #568ea9 underline
+inline = #a97156
+checkbox = #65a956
+checkbox_done = black
+code = on #eeeeee
 statusline = bold
-statusline_inactive = gray50
+statusline_inactive = #dddddd
 statusline_active = black
 
 info = dim cyan

--- a/uji.py
+++ b/uji.py
@@ -847,6 +847,8 @@ class UjiView(object):
             Keymapping('KEY_DOWN', 'down', func=self.cursor_down),
             Keymapping('KEY_UP', 'down', func=self.cursor_up),
             Keymapping(' ', 'page down', func=self.page_down),
+            Keymapping('KEY_PGDOWN', 'page down', func=self.page_down),
+            Keymapping('KEY_PGUP', 'page down', func=self.page_up),
             Keymapping('n', 'next', func=self.next),
             Keymapping('p', 'previous', func=self.previous),
             Keymapping('r', 'run command', flags=[KeymappingFlags.ONLY_ON_CHECKBOX, KeymappingFlags.EXECUTE], func=self.execute_command),
@@ -1023,6 +1025,9 @@ class UjiView(object):
 
     def page_down(self):
         self._update_view(self.view_offset + self.window.height)
+
+    def page_up(self):
+        self._update_view(self.view_offset - self.window.height)
 
     def next(self):
         for idx, l in enumerate(self.lines[self.cursor_offset + 1:]):

--- a/uji.py
+++ b/uji.py
@@ -974,7 +974,7 @@ class UjiView(object):
         elif self.cursor_offset > self.view_offset + self.window.height:
             self._update_cursor(self.view_offset + self.window.height)
 
-    def _handle_input(self, window, c):
+    def _handle_input(self, c):
         try:
             mapping = self.keymap[c]
             if not self.display_help or KeymappingFlags.ACTIVE_IN_HELP in mapping.flags:


### PR DESCRIPTION
Currently we handle our own colors and push the whole thing through curtsies. That's ... mostly unreadable and not flexible enough.

So this patchset switches rendering to python rich so we can do things like `[checkbox] .... [/checkbox]` and then apply a custom (rgb-capable) checkbox style.

But because curtsies limits our rgb-ness, switch to use blessed instead which coincidentally also makes our rendering much simpler - it's just a set of printfs now.

That and a few useful keybindings on top make uji view nicer to look at, and much more useful.