### PR TITLE
Use hash-prefixed headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 *.swp
+*.egg-info/

--- a/tests/test_uji.py
+++ b/tests/test_uji.py
@@ -22,9 +22,11 @@ def find_in_section(markdown: str, section: str, string: str) -> Optional[str]:
     prev_line = None
     in_section = False
     for line in markdown.split('\n'):
-        if prev_line is not None and prev_line == section and line == '-' * len(section):
+        if re.match(rf"^#*\s+{section}\s*$", line):  # # foo style header
             in_section = True
-        elif in_section and line == '':
+        elif prev_line is not None and prev_line == section and line == '-' * len(section):  # foo\n---\n style header
+            in_section = True
+        elif in_section and line == '' and prev_line is not None and not prev_line.startswith('#'):
             in_section = False
         elif in_section:
             if string in line:
@@ -62,10 +64,10 @@ def test_uji_tree(datadir):
         markdown = ''.join(open(md))
 
         # check for a few expected sections
-        assert 'Uji\n===\n' in markdown
-        assert 'actor1\n------\n' in markdown
-        assert 'actor2\n------\n' in markdown
-        assert 'Generic\n-------\n' in markdown
+        assert '# Uji\n' in markdown
+        assert '## actor1\n' in markdown
+        assert '## actor2\n' in markdown
+        assert '## Generic\n' in markdown
 
         # check for the tests to be distributed across the actors
         # correctly

--- a/uji.py
+++ b/uji.py
@@ -925,7 +925,7 @@ class UjiView(object):
 
         for l in lines:
             l = l[:-1]  # drop trailing \n
-            if l.startswith('```'):
+            if l.lstrip().startswith('```'):
                 in_code_section = not in_code_section
                 l = f'$BG_BRIGHT_YELLOW {" " * 80}$RESET'
             elif in_code_section:

--- a/uji.py
+++ b/uji.py
@@ -389,12 +389,10 @@ class MarkdownFormatter(object):
         print(text, file=self.fd)
 
     def h1(self, text):
-        self.fprint(text)
-        self.fprint('=' * len(text))
+        self.fprint(f'# {text}\n')
 
     def h2(self, text):
-        self.fprint(text)
-        self.fprint('-' * len(text))
+        self.fprint(f'## {text}\n')
 
     def h3(self, text):
         self.fprint(text)


### PR DESCRIPTION
Easier to find and parse than the ones that go over two lines