### PR TITLE
uji-view: convert the uji-check path to absolute

### DIFF
--- a/uji.py
+++ b/uji.py
@@ -1664,7 +1664,9 @@ def uji_check(directory):
         return
 
     try:
-        subprocess.check_output([os.fspath(precheck)], stderr=subprocess.STDOUT)
+        subprocess.check_output(
+            [os.fspath(precheck.absolute())], stderr=subprocess.STDOUT
+        )
     except subprocess.CalledProcessError as e:
         logger.critical(f"uji-check failed with exit code {e.returncode}. Aborting.")
         if e.output:


### PR DESCRIPTION
If `uji-view` is run with directory `.`, resolving the path skips the preceding directory components so we just end up with `uji-check` as executable. That will be looked up in $PATH and fail.